### PR TITLE
Update standardrb dependency to use newer gem named standard

### DIFF
--- a/guard-standardrb.gemspec
+++ b/guard-standardrb.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "guard", ">= 2.0.0"
   spec.add_dependency "guard-compat", "~> 1.0"
-  spec.add_dependency "standardrb"
+  spec.add_dependency "standard"
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.1"


### PR DESCRIPTION
The gem is no longer called `standardrb`. It's simply called `standard`. So this updates the gemspec to reference the newer version of the gem so that we can use a newer version of standard.